### PR TITLE
Don't run the checker when the process is trying to exit

### DIFF
--- a/obiwan/__init__.py
+++ b/obiwan/__init__.py
@@ -3,6 +3,8 @@ import gc
 import types
 import opcode
 import decimal
+import atexit
+import sys
 
 
 class ObiwanError(Exception):
@@ -342,10 +344,14 @@ def _runtime_checker(frame, evt, arg):
         # http://stackoverflow.com/a/12800909/15721
 
 
+def _atexit():
+    sys.settrace(None)
+
+
 def install_obiwan_runtime_check():
     if hasattr(_runtime_checker, "enabled") and _runtime_checker.enabled:
         return
-    import sys
     sys.settrace(_runtime_checker)
+    atexit.register(_atexit)
     _runtime_checker.lookup = {}
     _runtime_checker.enabled = True


### PR DESCRIPTION
When obiwan is running on complex code, it can end up trying to check functions that run as the process is exiting (presumably registered using `atexit.register()`). This doesn't work very well, because parts of the Python standard library may already have been deconstructed at that point:

```
Exception ignored in: <function WeakMethod.__new__.<locals>._cb at 0x7ff41464c730>
Traceback (most recent call last):
  File "/home/rspeer/.virtualenvs/lum3/lib/python3.4/weakref.py", line 50, in _cb
  File "/home/rspeer/.virtualenvs/lum3/lib/python3.4/site-packages/obiwan/__init__.py", line 317, in _runtime_checker
TypeError: 'NoneType' object is not callable
```

In this case, the object that can't be called because it's None is `gc.get_referrers`. I tried checking if that object was None, and then it instead crashed because `types.FunctionType` was None. All kinds of things can be None when you're exiting, it seems.

So, it seems that obiwan should also register an `atexit` which clears its `settrace` before anything else happens.
